### PR TITLE
Added a new 'time_zone' param for 'time_series' aggregates

### DIFF
--- a/lib/orchestrate/search/aggregate_builder.rb
+++ b/lib/orchestrate/search/aggregate_builder.rb
@@ -211,9 +211,6 @@ module Orchestrate::Search
     # @return [#to_s] The interval of time for the TimeSeries function
     attr_reader :interval
 
-    # @return [#to_s] The time zone for the TimeSeries function
-    attr_reader :time_zone
-
     extend Forwardable
 
     # Initialize a new TimeSeriesBuilder object
@@ -240,7 +237,7 @@ module Orchestrate::Search
 
     # @return Pretty-Printed string representation of the TimeSeriesBuilder object
     def to_s
-      "#<Orchestrate::Search::TimeSeriesBuilder collection=#{collection.name} field_name=#{field_name} interval=#{interval} time_zone=#{time_zone}>"
+      "#<Orchestrate::Search::TimeSeriesBuilder collection=#{collection.name} field_name=#{field_name} interval=#{interval} time_zone=#{@time_zone}>"
     end
     alias :inspect :to_s
 
@@ -249,7 +246,7 @@ module Orchestrate::Search
       if @time_zone.nil?
         "#{field_name}:time_series:#{interval}"
       else
-        "#{field_name}:time_series:#{interval}:#{time_zone}"
+        "#{field_name}:time_series:#{interval}:#{@time_zone}"
       end
     end
 

--- a/lib/orchestrate/search/aggregate_builder.rb
+++ b/lib/orchestrate/search/aggregate_builder.rb
@@ -211,6 +211,9 @@ module Orchestrate::Search
     # @return [#to_s] The interval of time for the TimeSeries function
     attr_reader :interval
 
+    # @return [#to_s] The time zone for the TimeSeries function
+    attr_reader :time_zone
+
     extend Forwardable
 
     # Initialize a new TimeSeriesBuilder object
@@ -220,6 +223,7 @@ module Orchestrate::Search
       @builder = builder
       @field_name = field_name
       @interval = nil
+      @time_zone = nil
     end
 
     def_delegator :@builder, :options
@@ -236,13 +240,17 @@ module Orchestrate::Search
 
     # @return Pretty-Printed string representation of the TimeSeriesBuilder object
     def to_s
-      "#<Orchestrate::Search::TimeSeriesBuilder collection=#{collection.name} field_name=#{field_name} interval=#{interval}>"
+      "#<Orchestrate::Search::TimeSeriesBuilder collection=#{collection.name} field_name=#{field_name} interval=#{interval} time_zone=#{time_zone}>"
     end
     alias :inspect :to_s
 
     # @return [#to_s] constructed aggregate string clause
     def to_param
-      "#{field_name}:time_series:#{interval}"
+      if @time_zone.nil?
+        "#{field_name}:time_series:#{interval}"
+      else
+        "#{field_name}:time_series:#{interval}:#{time_zone}"
+      end
     end
 
     # Set time series interval to year
@@ -284,6 +292,14 @@ module Orchestrate::Search
     # @return [AggregateBuilder]
     def hour
       @interval = 'hour'
+      self
+    end
+
+    # Use the designated time zone (e.g., "-0500" or "+0430") when calculating bucket boundaries
+    # @param zone [String]
+    # @return [RangeBuilder]
+    def time_zone(zone)
+      @time_zone = zone
       self
     end
   end

--- a/test/orchestrate/collection_aggregates_test.rb
+++ b/test/orchestrate/collection_aggregates_test.rb
@@ -59,7 +59,8 @@ class CollectionAggregates < MiniTest::Unit::TestCase
         "bucket" => "2014-11-01",
         "count" => 17
       }]
-    }]    @limit = 100
+    }]
+    @limit = 100
     @total = 110
 
     @make_listing = lambda{|i| make_kv_listing(:items, key: "item-#{i}", reftime: nil, score: @total-i/@total*5.0) }


### PR DESCRIPTION
Time-series aggregates can now be adjusted to use interval boundaries in your favorite time-zone (instead of the default UTC).

Please pay particular attention to the test suite here. I'm not 100% confident I understand how to write tests correctly for ruby.